### PR TITLE
Update version of edimax-smartplug

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 "version" : "0.1.0",
 "description" : "Node-RED node to access edimax smartplug",
 "dependencies": {
-	"edimax-smartplug": "^0.0.14",
+	"edimax-smartplug": "^0.0.19",
 	"bluebird": "^3.3.3"
 },
 "engines":


### PR DESCRIPTION
Update to latest version to ensure support for digest authentication (see [edimax-smartplug package issue](https://github.com/mwittig/edimax-smartplug/issues/3))
This is required for firmware v2.

Fixes issue #12